### PR TITLE
feat: get all threads and thread ids

### DIFF
--- a/pkg/controller/thread.go
+++ b/pkg/controller/thread.go
@@ -87,6 +87,17 @@ func (t *ThreadController) GetThreads(c *gin.Context) {
 		return
 	}
 
+	// TODO: optimize by having its own sql query
+	onlyIds := c.Query("only_ids")
+	if onlyIds == "true" {
+		var ids []uuid.UUID
+		for _, thread := range threads {
+			ids = append(ids, thread.ThreadId)
+		}
+		c.JSON(http.StatusOK, ids)
+		return
+	}
+
 	c.JSON(http.StatusOK, threads)
 }
 

--- a/pkg/persistence/repo/pgrepo/threadrepo/threadrepo.go
+++ b/pkg/persistence/repo/pgrepo/threadrepo/threadrepo.go
@@ -40,7 +40,7 @@ func (r *Repository) FindAll() ([]*core.Thread, error) {
 		return nil, fmt.Errorf("failed to find threads from versioned_thread table: %s", err)
 	}
 
-	// should the Thread Repository also fetch strings? or should that be done outside of this scope?
+	// TODO: fetch strings and remove string resolution from service layer
 
 	return convertVersionedThreadsToCoreThreads(versionedThreads), nil
 }

--- a/pkg/persistence/repo/pgrepo/threadrepo/threadrepo.go
+++ b/pkg/persistence/repo/pgrepo/threadrepo/threadrepo.go
@@ -40,7 +40,7 @@ func (r *Repository) FindAll() ([]*core.Thread, error) {
 		return nil, fmt.Errorf("failed to find threads from versioned_thread table: %s", err)
 	}
 
-	// TODO("Get strings")
+	// should the Thread Repository also fetch strings? or should that be done outside of this scope?
 
 	return convertVersionedThreadsToCoreThreads(versionedThreads), nil
 }
@@ -143,7 +143,8 @@ func convertVersionedThreadsToCoreThreads(versionedThreads []*threaddao.Versione
 	var threads []*core.Thread
 
 	for _, t := range versionedThreads {
-		threads = append(threads, t.ToThread(nil)) // TODO: Need strings
+		// TODO: Need strings? right now the ThreadService manages getting and setting the strings
+		threads = append(threads, t.ToThread(nil))
 	}
 
 	return threads

--- a/pkg/service/thread.go
+++ b/pkg/service/thread.go
@@ -293,7 +293,20 @@ func (t *ThreadService) updateAndCreateStrings(clientThread, serverThread *core.
 }
 
 func (t *ThreadService) GetThreads() ([]*core.Thread, error) {
-	return t.ThreadRepository.FindAll()
+	threads, err := t.ThreadRepository.FindAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get threads: %s", err)
+	}
+
+	for _, thread := range threads {
+		strings, err := t.StringRepository.FindAllByThreadId(thread.ThreadId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get strings for thread %s: %s", thread.ThreadId, err)
+		}
+		thread.Strings = strings
+	}
+
+	return threads, nil
 }
 
 func (t *ThreadService) GetThreadIds() ([]uuid.UUID, error) {

--- a/pkg/service/thread.go
+++ b/pkg/service/thread.go
@@ -298,6 +298,7 @@ func (t *ThreadService) GetThreads() ([]*core.Thread, error) {
 		return nil, fmt.Errorf("failed to get threads: %s", err)
 	}
 
+	// TODO: have ThreadRepository return threads with strings
 	for _, thread := range threads {
 		strings, err := t.StringRepository.FindAllByThreadId(thread.ThreadId)
 		if err != nil {


### PR DESCRIPTION
get all threads with strings

if `only_ids` query param, return just array of ids

Open question: not sure whether the ThreadRepository should accept a StringsRepository and be responsible for fetching strings as well or if its okay for the ThreadService to manage that.

Another question is should the ThreadService pass off and expect core.Thread or the object relevant to to the Repositories. 

My guess is that if Repositories are meant to be swapped out, should stick with core.Thread.

Which makes me think that, yes, ThreadRepository should fetch all the strings.